### PR TITLE
1.7.0 -> 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v2.0.0 (2023-02-16)
+Dusting-off/ updating after 17 months
+
+** Breaking changes **
+- Renamed all exceptions to end in 'Error' to be consistent with 
+- Drops python 3.7
+
+** Other changes **
+- CHANGELOG.md now updated manually, drops automated github-based changelogs.
+- Package management now consistent with [pep 517](https://peps.python.org/pep-0517/), using poetry
+- Replaces module-level rst files like README with markup (md) files. Docs are still rst/sphinx based though
+- Updates pre-commit enforced static flake8 and black versions
+- Updates all requirements, now manages dev requirements with poetry instead of separate requirements_dev
+
+
 ## [v1.7.0](https://github.com/sjoerdk/anonapi/tree/v1.7.0) (2021-09-29)
 
 [Full Changelog](https://github.com/sjoerdk/anonapi/compare/v1.6.0...v1.7.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@
 ## v2.0.0 (2023-02-16)
 Dusting-off/ updating after 17 months
 
-** Breaking changes **
+**Breaking changes:**
 - Renamed all exceptions to end in 'Error' to be consistent with 
 - Drops python 3.7
 
-** Other changes **
+**Other changes:**
 - CHANGELOG.md now updated manually, drops automated github-based changelogs.
 - Package management now consistent with [pep 517](https://peps.python.org/pep-0517/), using poetry
 - Replaces module-level rst files like README with markup (md) files. Docs are still rst/sphinx based though

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "anonapi"
-version = "1.7.0"
+version = "2.0.0"
 description = "Client and tools for working with the anoymization web API"
 authors = ["sjoerdk <sjoerd.kerkstra@radboudumc.nl>"]
 readme = "README.md"


### PR DESCRIPTION
## v2.0.0 (2023-02-16)
Dusting-off/ updating after 17 months

**Breaking changes:**
- Renamed all exceptions to end in 'Error' to be consistent with 
- Drops python 3.7

**Other changes:**
- CHANGELOG.md now updated manually, drops automated github-based changelogs.
- Package management now consistent with [pep 517](https://peps.python.org/pep-0517/), using poetry
- Replaces module-level rst files like README with markup (md) files. Docs are still rst/sphinx based though
- Updates pre-commit enforced static flake8 and black versions
- Updates all requirements, now manages dev requirements with poetry instead of separate requirements_dev