### PR TITLE
Fix Flaky Test: test_job_parameter_set

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -34,7 +34,7 @@ class PatientNameFactory(factory.Factory):
     class Meta:
         model = PseudoName
 
-    value = factory.sequence(lambda n: f"patientName{n}")
+    value = "patientName0"
 
 
 class ProjectFactory(factory.Factory):


### PR DESCRIPTION
I ran pytest tests/test_cli_create.py --flake-finder and discovered test_job_parameter_set failing intermittently. Previously, the PatientNameFactory generated values like patientName1, patientName2, etc., causing intermittent test failures in test_job_parameter_set. This PR fixes flakiness in tests related to PatientNameFactory by setting a consistent value for the value field of the PseudoName model. Setting a fixed value of "patientName0" ensures consistent behavior across test runs.